### PR TITLE
Add DentalSegmentator to MOOSE

### DIFF
--- a/moosez/models.py
+++ b/moosez/models.py
@@ -124,6 +124,11 @@ MODEL_METADATA = {
         KEY_URL: "https://enhance-pet.s3.eu-central-1.amazonaws.com/moose/clin_ct_fat_31082023.zip",
         KEY_FOLDER_NAME: "Dataset777_Fat",
         KEY_LIMIT_FOV: None
+    },
+    "clin_ct_dental": {
+        KEY_URL: "https://model.s.mdforge.com/Dataset112_DentalSegmentator_v100_moose.zip",
+        KEY_FOLDER_NAME: "Dataset112_DentalSegmentator_v100",
+        KEY_LIMIT_FOV: None
     }
 }
 


### PR DESCRIPTION
As discussed on Discord, I would like to add DentalSegmentator directly to MOOSE so that I don't have to maintain a fork for it.
I need to reupload the weight from Zenodo to our server because original weight uses `fold_0` and MOOSE expects `fold_all`

DentalSegmentator information:

- Repo: https://github.com/gaudot/SlicerDentalSegmentator
- Paper: https://doi.org/10.1016/j.jdent.2024.105130
- Original weight URL: https://zenodo.org/records/10829675 
- New weight URL: https://model.s.mdforge.com/Dataset112_DentalSegmentator_v100_moose.zip
- License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
- Citations: 
> Dot, G. (2024). DentalSegmentator nnU-Net pretrained model for CBCT image segmentation. Zenodo. https://doi.org/10.5281/zenodo.10829675