### PR TITLE
fix: apply transpose for voxel_spacing

### DIFF
--- a/moosez/models.py
+++ b/moosez/models.py
@@ -149,7 +149,9 @@ class Model:
         self.trainer, self.planner, self.resolution_configuration = self.__get_model_configuration()
 
         self.dataset, self.plans = self.__get_model_data()
-        self.voxel_spacing = tuple(self.plans.get('configurations').get(self.resolution_configuration).get('spacing', DEFAULT_SPACING))
+        self.voxel_spacing = self.plans.get('configurations').get(self.resolution_configuration).get('spacing', DEFAULT_SPACING)
+        self.voxel_spacing = tuple([self.voxel_spacing[i] for i in self.plans.get("transpose_forward")])
+      
         self.imaging_type, self.modality, self.region = self.__get_model_identifier_segments()
         self.multilabel_prefix = f"{self.imaging_type}_{self.modality}_{self.region}_"
 


### PR DESCRIPTION
Transposed axes in nnUNet experiments place the largest spacing first. Voxel spacing in plans.json is stored in transposed order, so a backward transpose is needed to restore the original ZYX order when using SimpleITK.

Reference for nnUNet experiment planner:
https://github.com/MIC-DKFZ/nnUNet/blob/3df680c6d28ea88735fca1c1921df380471c1af6/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py#L215-L226