### PR TITLE
Custom trainer fix for packages

### DIFF
--- a/moosez/moosez.py
+++ b/moosez/moosez.py
@@ -357,8 +357,7 @@ def moose(input_data: Union[str, Tuple[numpy.ndarray, Tuple[float, float, float]
     file_utilities.create_directory(model_path)
     model_routine = models.construct_model_routine(model_names, output_manager)
 
-    status = add_custom_trainers_to_local_nnunetv2()
-    print(status)
+    add_custom_trainers_to_local_nnunetv2()
 
     if accelerator is None:
         accelerator, _ = system.check_device(output_manager)

--- a/moosez/moosez.py
+++ b/moosez/moosez.py
@@ -357,6 +357,9 @@ def moose(input_data: Union[str, Tuple[numpy.ndarray, Tuple[float, float, float]
     file_utilities.create_directory(model_path)
     model_routine = models.construct_model_routine(model_names, output_manager)
 
+    status = add_custom_trainers_to_local_nnunetv2()
+    print(status)
+
     if accelerator is None:
         accelerator, _ = system.check_device(output_manager)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.0.13",
+    version="3.0.14",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
Custom trainer files are now installed using the MOOSE package version. 

setup.py
- elevated version to 3.0.14

moosez.py
- added the function call for add_custom_trainers_to_local_nnunetv2() to moose() to install the custom trainer in package usage automatically