### PR TITLE
Removed torch version restriction from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.0.14",
+    version="3.0.15",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',
@@ -31,7 +31,7 @@ setup(
              ' preclinical-segmentation clinical-segmentation',
     packages=find_packages(),
     install_requires=[
-        'torch<2.6',
+        'torch',
         'SimpleITK',
         'acvl-utils==0.2',
         'nnunetv2',


### PR DESCRIPTION
This was an old measurement to reduce incompatibilities between `torch` and `numpy` due to major version releases between November 2024 and January 2025. `torch` will not be uninstalled anymore now when a version > 2.6 was installed before `moosez`.

- Bumped version to 3.0.15 (from 3.0.14)
- Tested with UX and VSN on 
  - Windows 11 and Python 3.10 ✅ 
  - Ubuntu 22.04 and Python 3.10 ✅ 

This was mentioned in #182 