### PR TITLE
FIX: off-by-one error in chunking and wrong prediction output sizes | #186

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.0.18",
+    version="3.0.19",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     long_description='mooseZ is an AI-inference engine based on nnUNet, designed for 3D clinical and preclinical'
                      ' whole-body segmentation tasks. It serves models tailored towards different modalities such'
                      ' as PET, CT, and MR. mooseZ provides fast and accurate segmentation results, making it a '
@@ -21,7 +21,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Medical Science Apps.',
     ],
 
@@ -33,13 +32,13 @@ setup(
     install_requires=[
         'torch',
         'SimpleITK',
-        'nnunetv2',
+        'nnunetv2>=2.6.0',
         'halo~=0.0.31',
         'pydicom~=2.2.2',
-        'argparse~=1.4.0',
+        'argparse',
         'numpy<2.0',
         'pyfiglet~=0.8.post1',
-        'natsort~=8.1.0',
+        'natsort',
         'colorama~=0.4.6',
         'dask',
         'rich',


### PR DESCRIPTION
This PR introduces a crucial fix to the prediction pipeline, stabilizes image chunking behavior, enhances logging, and updates package metadata and compatibility requirements.

- Version bump: Project version elevated to `3.0.19`.
- ⚠️ Python compatibility: The minimum required Python version is now `3.10`.
- Package dependencies updated:
  - Removed unnecessary version constraints on `natsort` and `argparse`.
  - ⚠️ Added a lower bound constraint on `nnunetv2` (`>=2.6.0`) for compatibility.

**Fixed shared mutable state bug**
- The `preprocessing_iterator_from_array()` function now creates a separate copy of `image_properties` for each chunk.
  - Previously, a single dictionary reference was passed to all chunks, causing unintended side effects due to in-place modification.
  - Now, each chunk receives an independent dictionary, ensuring isolated and predictable preprocessing behavior.
  - This originates from a change within `dask` from version `2025.03` to `2025.04` in how shared resources are handled

**Improved logging**
- Added more detailed logging output for created image chunks

**Chunking stability**
- `determine_splits()` in `ImageChunker` now uses `math.ceil()` to calculate the number of splits along each axis.
  - This replaces the previous logic of int(x + 0.5), which could result in rounding inconsistencies.
- `__compute_interior_indices()` now avoids rounding chunk extents, which prevents off-by-one errors. The chunking is now based on integer operations only, which will rule out any future rounding issues 

This PR is loosely related to #186.